### PR TITLE
Stops Open book form moving by colision of other objects

### DIFF
--- a/Char Ring
+++ b/Char Ring
@@ -476,6 +476,7 @@ function openBook(book,zone)
     obj.setLuaScript(code)
     obj.setVar('open', 1)
     obj['interactable'] = false
+	obj.setLock(true)
     CharacterJournals[keyFromValue(Global.getTable('zoneFromColor'),zone.guid)] = obj
     readFromBook(keyFromValue(Global.getTable('zoneFromColor'),zone.guid),book)
     book.destruct()

--- a/Char Ring
+++ b/Char Ring
@@ -476,7 +476,7 @@ function openBook(book,zone)
     obj.setLuaScript(code)
     obj.setVar('open', 1)
     obj['interactable'] = false
-	obj.setLock(true)
+    obj.setLock(true)
     CharacterJournals[keyFromValue(Global.getTable('zoneFromColor'),zone.guid)] = obj
     readFromBook(keyFromValue(Global.getTable('zoneFromColor'),zone.guid),book)
     book.destruct()


### PR DESCRIPTION
The open character sheet book model could be moved by collision with
other objects. As the book had the interactable == false, the behaviour
seemed to be unintended. By adding the setLock(true) one stops the model
form moving.